### PR TITLE
Improve Pixels Dice integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This custom component integrates Pixels Dice with Home Assistant, allowing you t
 ## Features
 
 *   **Sensor Entity:** Provides a sensor that updates with the current roll state of your Pixels Dice (e.g., "Landed: 1", "Rolling", "Handling").
+*   **Presence Binary Sensor:** Indicates when the dice is advertising over Bluetooth. It turns `on` when detected nearby and `off` when out of range.
 *   **Connect/Disconnect Services:** Offers Home Assistant services to manually connect to and disconnect from your Pixels Dice, helping to conserve battery life.
 
 ## Installation (HACS)
@@ -58,6 +59,12 @@ Connects to the specified Pixels Dice.
 ```yaml
 entity_id: sensor.pixels_dice_brian_pd6 # Replace with your sensor's entity ID
 ```
+
+## Presence Sensor
+
+The integration creates a binary sensor named after your die, such as `Brian PD6 Presence`.
+The sensor is `on` while Bluetooth advertisements from the die are detected and
+turns `off` once those advertisements stop.
 
 ### `pixels_dice.disconnect`
 

--- a/custom_components/pixels_dice/__init__.py
+++ b/custom_components/pixels_dice/__init__.py
@@ -27,7 +27,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        pixels_device = hass.data[DOMAIN].pop(entry.unique_id, None)
+        if pixels_device:
+            await pixels_device.async_will_remove_from_hass()
 
     return unload_ok
 

--- a/custom_components/pixels_dice/sensor.py
+++ b/custom_components/pixels_dice/sensor.py
@@ -29,12 +29,13 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Pixels Dice sensor platform."""
     _LOGGER.debug("Setting up Pixels Dice sensor platform from config entry")
-    print("async_setup_entry called")
     die_name = config_entry.data["name"]
     unique_id = config_entry.unique_id
 
     pixels_device = PixelsDiceDevice(hass, die_name, unique_id)
     hass.data.setdefault(DOMAIN, {})[unique_id] = pixels_device
+
+    await pixels_device.async_added_to_hass()
 
     await async_add_entities([
         PixelsDiceStateSensor(pixels_device),


### PR DESCRIPTION
## Summary
- call `async_added_to_hass` before registering entities
- clean up debug log
- cleanup `async_unload_entry` to remove device properly
- document presence sensor usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_686851163cac8326b61b9cc566614f24