### PR TITLE
Fix presence sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This custom component integrates Pixels Dice with Home Assistant, allowing you t
 ## Features
 
 *   **Sensor Entity:** Provides a sensor that updates with the current roll state of your Pixels Dice (e.g., "Landed: 1", "Rolling", "Handling").
+*   **Presence Binary Sensor:** Indicates when the dice is advertising over Bluetooth. It turns `on` when detected nearby and `off` when out of range.
 *   **Connect/Disconnect Services:** Offers Home Assistant services to manually connect to and disconnect from your Pixels Dice, helping to conserve battery life.
 
 ## Installation (HACS)
@@ -58,6 +59,12 @@ Connects to the specified Pixels Dice.
 ```yaml
 entity_id: sensor.pixels_dice_brian_pd6 # Replace with your sensor's entity ID
 ```
+
+## Presence Sensor
+
+The integration creates a binary sensor named after your die, such as `Brian PD6 Presence`.
+The sensor is `on` while Bluetooth advertisements from the die are detected and
+turns `off` once those advertisements stop.
 
 ### `pixels_dice.disconnect`
 

--- a/custom_components/pixels_dice/__init__.py
+++ b/custom_components/pixels_dice/__init__.py
@@ -27,7 +27,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        pixels_device = hass.data[DOMAIN].get(entry.unique_id)
+        if pixels_device:
+            await pixels_device.async_will_remove_from_hass()
+            hass.data[DOMAIN].pop(entry.unique_id, None)
 
     return unload_ok
 


### PR DESCRIPTION
## Summary
- call `async_added_to_hass` before registering entities
- clean up debug log
- cleanup `async_unload_entry` to remove device properly
- document presence sensor usage
- fix bluetooth callback registration
- add tests for presence and initialization order

## Testing
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686851163cac8326b61b9cc566614f24