### PR TITLE
Add device triggers for Pixels Dice

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This custom component integrates Pixels Dice with Home Assistant, allowing you t
 *   **Autoconnect Switch:** A switch entity that allows you to control whether Home Assistant should automatically connect to the die when it's detected.
 *   **Connect/Disconnect Buttons:** Provides buttons to manually connect and disconnect from the die.
 *   **Connect/Disconnect Services:** Offers Home Assistant services to manually connect to and disconnect from your Pixels Dice, helping to conserve battery life.
+*   **Device Triggers:** Rolling state and face value are available as device triggers for automations.
 
 ## Installation (HACS)
 
@@ -64,6 +65,10 @@ This integration creates several sensors to monitor your Pixels die:
   - A timestamp of when the die was last detected by Home Assistant.
 - **RSSI Sensor:** `sensor.your_die_name_rssi`
   - The Received Signal Strength Indicator (RSSI) in dBm, which indicates how strong the Bluetooth signal is.
+
+## Device Triggers
+
+Face and state sensors appear as device triggers so you can easily create automations for specific roll values or states without referencing entity IDs.
 
 ## Autoconnect Switch
 

--- a/custom_components/pixels_dice/device_trigger.py
+++ b/custom_components/pixels_dice/device_trigger.py
@@ -1,0 +1,91 @@
+"""Device triggers for Pixels Dice sensors."""
+from __future__ import annotations
+
+from typing import Any, Callable, Final
+
+import voluptuous as vol
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_PLATFORM,
+)
+
+CONF_FROM = "from"
+CONF_TO = "to"
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.event import async_track_state_change_event
+
+from .const import DOMAIN
+
+TRIGGER_TYPES: Final = {"face", "state"}
+
+TRIGGER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_PLATFORM): "device",
+        vol.Required(CONF_DEVICE_ID): str,
+        vol.Required("type"): vol.In(TRIGGER_TYPES),
+        vol.Required(CONF_ENTITY_ID): str,
+        vol.Optional(CONF_FROM): str,
+        vol.Optional(CONF_TO): str,
+    }
+)
+
+
+async def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, Any]]:
+    """Return a list of triggers for the device."""
+    triggers: list[dict[str, Any]] = []
+    ent_reg = er.async_get(hass)
+    for entry in er.async_entries_for_device(ent_reg, device_id, True):
+        if entry.domain != "sensor" or entry.platform != DOMAIN:
+            continue
+        if entry.unique_id.endswith("_face"):
+            triggers.append(
+                {
+                    CONF_PLATFORM: "device",
+                    CONF_DOMAIN: DOMAIN,
+                    CONF_DEVICE_ID: device_id,
+                    CONF_ENTITY_ID: entry.entity_id,
+                    "type": "face",
+                }
+            )
+        elif entry.unique_id.endswith("_state"):
+            triggers.append(
+                {
+                    CONF_PLATFORM: "device",
+                    CONF_DOMAIN: DOMAIN,
+                    CONF_DEVICE_ID: device_id,
+                    CONF_ENTITY_ID: entry.entity_id,
+                    "type": "state",
+                }
+            )
+    return triggers
+
+
+def async_get_trigger_capabilities(hass: HomeAssistant, trigger: dict[str, Any]) -> vol.Schema:
+    """Return the capabilities for a device trigger."""
+    return vol.Schema({vol.Optional(CONF_FROM): str, vol.Optional(CONF_TO): str})
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: dict[str, Any],
+    action: Callable[..., Any],
+    automation_info: dict[str, Any],
+) -> Callable[[], None]:
+    """Attach a trigger."""
+    entity_id = config[CONF_ENTITY_ID]
+    to_state = config.get(CONF_TO)
+    from_state = config.get(CONF_FROM)
+
+    async def state_changed(event):
+        old = event.data.get("old_state")
+        new = event.data.get("new_state")
+        if from_state is not None and (old is None or old.state != from_state):
+            return
+        if to_state is not None and (new is None or new.state != to_state):
+            return
+        await action({})
+
+    return async_track_state_change_event(hass, [entity_id], state_changed)

--- a/custom_components/pixels_dice/device_trigger.py
+++ b/custom_components/pixels_dice/device_trigger.py
@@ -10,14 +10,14 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_PLATFORM,
 )
-
-CONF_FROM = "from"
-CONF_TO = "to"
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.event import async_track_state_change_event
 
 from .const import DOMAIN
+
+CONF_FROM = "from"
+CONF_TO = "to"
 
 TRIGGER_TYPES: Final = {"face", "state"}
 

--- a/tests/test_device_trigger.py
+++ b/tests/test_device_trigger.py
@@ -1,0 +1,82 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_PLATFORM,
+)
+
+from custom_components.pixels_dice import device_trigger
+from custom_components.pixels_dice.const import DOMAIN
+
+
+@pytest.mark.asyncio
+async def test_async_get_triggers(hass):
+    """Device triggers are created for face and state sensors."""
+    entries = [
+        SimpleNamespace(domain="sensor", platform=DOMAIN, unique_id="die_face", entity_id="sensor.die_face"),
+        SimpleNamespace(domain="sensor", platform=DOMAIN, unique_id="die_state", entity_id="sensor.die_state"),
+    ]
+
+    with patch("custom_components.pixels_dice.device_trigger.er.async_get"), patch(
+        "custom_components.pixels_dice.device_trigger.er.async_entries_for_device",
+        return_value=entries,
+    ):
+        triggers = await device_trigger.async_get_triggers(hass, "device123")
+
+    assert triggers == [
+        {
+            CONF_PLATFORM: "device",
+            CONF_DOMAIN: DOMAIN,
+            CONF_DEVICE_ID: "device123",
+            CONF_ENTITY_ID: "sensor.die_face",
+            "type": "face",
+        },
+        {
+            CONF_PLATFORM: "device",
+            CONF_DOMAIN: DOMAIN,
+            CONF_DEVICE_ID: "device123",
+            CONF_ENTITY_ID: "sensor.die_state",
+            "type": "state",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_attach_trigger_calls_action(hass):
+    """The trigger fires when state transitions match."""
+    callbacks = []
+
+    def fake_track(hass, entity_ids, callback):
+        callbacks.append(callback)
+        return lambda: None
+
+    action = AsyncMock()
+
+    with patch(
+        "custom_components.pixels_dice.device_trigger.async_track_state_change_event",
+        side_effect=fake_track,
+    ):
+        await device_trigger.async_attach_trigger(
+            hass,
+            {
+                CONF_ENTITY_ID: "sensor.die_state",
+                device_trigger.CONF_FROM: "Rolling",
+                device_trigger.CONF_TO: "Landed",
+            },
+            action,
+            {},
+        )
+
+    event = SimpleNamespace(
+        data={
+            "old_state": SimpleNamespace(state="Rolling"),
+            "new_state": SimpleNamespace(state="Landed"),
+        }
+    )
+    await callbacks[0](event)
+
+    action.assert_awaited_once()


### PR DESCRIPTION
## Summary
- add a `device_trigger` module implementing face/state triggers
- document device triggers in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad720fc208326bc7c61c59c72693b